### PR TITLE
Use NULL to initialize pointers

### DIFF
--- a/examples/cfgtest.c
+++ b/examples/cfgtest.c
@@ -71,7 +71,7 @@ int cb_validate_bookmark(cfg_t *cfg, cfg_opt_t *opt)
 		cfg_error(cfg, "section is NULL!?");
 		return -1;
 	}
-	if (cfg_getstr(sec, "machine") == 0) {
+	if (cfg_getstr(sec, "machine") == NULL) {
 		cfg_error(cfg, "machine option must be set for bookmark '%s'", cfg_title(sec));
 		return -1;
 	}
@@ -88,17 +88,17 @@ int main(int argc, char **argv)
 
 	cfg_opt_t proxy_opts[] = {
 		CFG_INT("type", 0, CFGF_NONE),
-		CFG_STR("host", 0, CFGF_NONE),
+		CFG_STR("host", NULL, CFGF_NONE),
 		CFG_STR_LIST("exclude", "{localhost, .localnet}", CFGF_NONE),
 		CFG_INT("port", 21, CFGF_NONE),
 		CFG_END()
 	};
 	cfg_opt_t bookmark_opts[] = {
-		CFG_STR("machine", 0, CFGF_NONE),
+		CFG_STR("machine", NULL, CFGF_NONE),
 		CFG_INT("port", 21, CFGF_NONE),
-		CFG_STR("login", 0, CFGF_NONE),
-		CFG_STR("password", 0, CFGF_NONE),
-		CFG_STR("directory", 0, CFGF_NONE),
+		CFG_STR("login", NULL, CFGF_NONE),
+		CFG_STR("password", NULL, CFGF_NONE),
+		CFG_STR("directory", NULL, CFGF_NONE),
 		CFG_BOOL("passive-mode", cfg_false, CFGF_NONE),
 		CFG_SEC("proxy", proxy_opts, CFGF_NONE),
 		CFG_END()
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 		if (pxy) {
 			int j, m;
 
-			if (cfg_getstr(pxy, "host") == 0) {
+			if (cfg_getstr(pxy, "host") == NULL) {
 				printf("      no proxy host is set, setting it to 'localhost'...\n");
 				/* For sections without CFGF_MULTI flag set, there is
 				 * also an extended syntax to get an option in a

--- a/examples/cli.c
+++ b/examples/cli.c
@@ -295,9 +295,9 @@ int main(void)
 	};
 
 	cfg_opt_t opts[] = {
-		CFG_BOOL_LIST("bool", cfg_false, CFGF_NONE),
+		CFG_BOOL_LIST("bool", NULL, CFGF_NONE),
 		CFG_STR_LIST("string", NULL, CFGF_NONE),
-		CFG_INT_LIST("int", 0, CFGF_NONE),
+		CFG_INT_LIST("int", NULL, CFGF_NONE),
 		CFG_FLOAT_LIST("float", "0.0", CFGF_NONE),
 		CFG_SEC("sub", sub_opts,
 			CFGF_MULTI | CFGF_TITLE | CFGF_NO_TITLE_DUPES),

--- a/examples/ftpconf.c
+++ b/examples/ftpconf.c
@@ -67,11 +67,11 @@ int conf_validate_bookmark(cfg_t *cfg, cfg_opt_t *opt)
 cfg_t *parse_conf(const char *filename)
 {
 	static cfg_opt_t bookmark_opts[] = {
-		CFG_STR("host", 0, CFGF_NODEFAULT),
+		CFG_STR("host", NULL, CFGF_NODEFAULT),
 		CFG_INT("port", 21, CFGF_NONE),
 		CFG_STR("login", "anonymous", CFGF_NONE),
 		CFG_STR("password", "anonymous@", CFGF_NONE),
-		CFG_STR("directory", 0, CFGF_NONE),
+		CFG_STR("directory", NULL, CFGF_NONE),
 		CFG_END()
 	};
 
@@ -98,7 +98,7 @@ cfg_t *parse_conf(const char *filename)
 	case CFG_SUCCESS:
 		break;
 	case CFG_PARSE_ERROR:
-		return 0;
+		return NULL;
 	}
 
 	return cfg;

--- a/examples/reread.c
+++ b/examples/reread.c
@@ -5,7 +5,7 @@
 #include <locale.h>
 #include "confuse.h"
 
-cfg_t *cfg = 0;
+cfg_t *cfg = NULL;
 const char *config_filename = "./reread.conf";
 
 void read_config(void)
@@ -73,7 +73,7 @@ int main(void)
 	}
 
 	cfg_free(cfg);
-	cfg = 0;
+	cfg = NULL;
 
 	return 0;
 }

--- a/src/confuse.c
+++ b/src/confuse.c
@@ -59,7 +59,7 @@ const char confuse_version[] = PACKAGE_VERSION;
 const char confuse_copyright[] = PACKAGE_STRING " by Martin Hedenfalk <martin@bzero.se>";
 const char confuse_author[] = "Martin Hedenfalk <martin@bzero.se>";
 
-char *cfg_yylval = 0;
+char *cfg_yylval = NULL;
 
 extern int  cfg_yylex(cfg_t *cfg);
 extern void cfg_yylex_destroy(void);
@@ -858,7 +858,7 @@ static void cfg_init_defaults(cfg_t *cfg)
 			cfg->opts[i].flags |= CFGF_RESET;
 			cfg->opts[i].flags &= ~CFGF_MODIFIED;
 		} else if (!is_set(CFGF_MULTI, cfg->opts[i].flags)) {
-			cfg_setopt(cfg, &cfg->opts[i], 0);
+			cfg_setopt(cfg, &cfg->opts[i], NULL);
 			cfg->opts[i].flags |= CFGF_DEFINIT;
 		}
 	}
@@ -1002,7 +1002,7 @@ DLLIMPORT cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
 		break;
 
 	case CFGT_SEC:
-		if (is_set(CFGF_MULTI, opt->flags) || val->section == 0) {
+		if (is_set(CFGF_MULTI, opt->flags) || val->section == NULL) {
 			if (val->section) {
 				val->section->path = NULL; /* Global search path */
 				cfg_free(val->section);
@@ -1102,7 +1102,7 @@ DLLIMPORT int cfg_opt_setmulti(cfg_t *cfg, cfg_opt_t *opt, unsigned int nvalues,
 
 	old = *opt;
 	opt->nvalues = 0;
-	opt->values = 0;
+	opt->values = NULL;
 
 	for (i = 0; i < nvalues; i++) {
 		if (cfg_setopt(cfg, opt, values[i]))
@@ -1273,7 +1273,8 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 	char *opttitle = NULL;
 	cfg_opt_t *opt = NULL;
 	cfg_value_t *val = NULL;
-	cfg_opt_t funcopt = CFG_STR(0, 0, 0);
+	cfg_opt_t funcopt = CFG_STR(NULL, NULL, 0);
+
 	int ignore = 0;		/* ignore until this token, traverse parser w/o error */
 	int num_values = 0;	/* number of values found for a list option */
 	int rc;
@@ -1419,7 +1420,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 				goto error;
 			}
 
-			if (cfg_setopt(cfg, opt, cfg_yylval) == 0)
+			if (cfg_setopt(cfg, opt, cfg_yylval) == NULL)
 				goto error;
 
 			if (opt && opt->validcb && (*opt->validcb) (cfg, opt) != 0)
@@ -1446,7 +1447,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 					goto error;
 				}
 
-				if (cfg_setopt(cfg, opt, cfg_yylval) == 0)
+				if (cfg_setopt(cfg, opt, cfg_yylval) == NULL)
 					goto error;
 				if (opt && opt->validcb && (*opt->validcb) (cfg, opt) != 0)
 					goto error;
@@ -1487,7 +1488,7 @@ static int cfg_parse_internal(cfg_t *cfg, int level, int force_state, cfg_opt_t 
 			val->section->path = cfg->path; /* Remember global search path */
 			val->section->line = cfg->line;
 			val->section->errfunc = cfg->errfunc;
-			rc = cfg_parse_internal(val->section, level + 1, -1, 0);
+			rc = cfg_parse_internal(val->section, level + 1, -1, NULL);
 			if (rc != STATE_EOF)
 				goto error;
 
@@ -1835,9 +1836,9 @@ DLLIMPORT cfg_t *cfg_init(cfg_opt_t *opts, cfg_flag_t flags)
 	}
 
 	cfg->flags = flags;
-	cfg->filename = 0;
+	cfg->filename = NULL;
 	cfg->line = 0;
-	cfg->errfunc = 0;
+	cfg->errfunc = NULL;
 
 #if defined(ENABLE_NLS) && defined(HAVE_GETTEXT)
 	bindtextdomain(PACKAGE, LOCALEDIR);
@@ -1850,13 +1851,13 @@ DLLIMPORT cfg_t *cfg_init(cfg_opt_t *opts, cfg_flag_t flags)
 
 DLLIMPORT char *cfg_tilde_expand(const char *filename)
 {
-	char *expanded = 0;
+	char *expanded = NULL;
 
 #ifndef _WIN32
 	/* Do tilde expansion */
 	if (filename[0] == '~') {
-		struct passwd *passwd = 0;
-		const char *file = 0;
+		struct passwd *passwd = NULL;
+		const char *file = NULL;
 
 		if (filename[1] == '/' || filename[1] == 0) {
 			/* ~ or ~/path */
@@ -1867,7 +1868,7 @@ DLLIMPORT char *cfg_tilde_expand(const char *filename)
 			char *user;
 
 			file = strchr(filename, '/');
-			if (file == 0)
+			if (file == NULL)
 				file = filename + strlen(filename);
 
 			user = malloc(file - filename);
@@ -2013,7 +2014,7 @@ DLLIMPORT int cfg_include(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **arg
 
 static cfg_value_t *cfg_opt_getval(cfg_opt_t *opt, unsigned int index)
 {
-	cfg_value_t *val = 0;
+	cfg_value_t *val = NULL;
 
 	if (index != 0 && !is_set(CFGF_LIST, opt->flags) && !is_set(CFGF_MULTI, opt->flags)) {
 		errno = EINVAL;
@@ -2517,12 +2518,12 @@ static int cfg_opt_print_pff_indent(cfg_opt_t *opt, FILE *fp,
 
 DLLIMPORT int cfg_opt_print_indent(cfg_opt_t *opt, FILE *fp, int indent)
 {
-	return cfg_opt_print_pff_indent(opt, fp, 0, indent);
+	return cfg_opt_print_pff_indent(opt, fp, NULL, indent);
 }
 
 DLLIMPORT int cfg_opt_print(cfg_opt_t *opt, FILE *fp)
 {
-	return cfg_opt_print_pff_indent(opt, fp, 0, 0);
+	return cfg_opt_print_pff_indent(opt, fp, NULL, 0);
 }
 
 static int cfg_print_pff_indent(cfg_t *cfg, FILE *fp,
@@ -2542,12 +2543,12 @@ static int cfg_print_pff_indent(cfg_t *cfg, FILE *fp,
 
 DLLIMPORT int cfg_print_indent(cfg_t *cfg, FILE *fp, int indent)
 {
-	return cfg_print_pff_indent(cfg, fp, 0, indent);
+	return cfg_print_pff_indent(cfg, fp, NULL, indent);
 }
 
 DLLIMPORT int cfg_print(cfg_t *cfg, FILE *fp)
 {
-	return cfg_print_pff_indent(cfg, fp, 0, 0);
+	return cfg_print_pff_indent(cfg, fp, NULL, 0);
 }
 
 DLLIMPORT cfg_print_func_t cfg_opt_set_print_func(cfg_opt_t *opt, cfg_print_func_t pf)
@@ -2607,7 +2608,7 @@ static cfg_opt_t *cfg_getopt_array(cfg_opt_t *rootopts, int cfg_flags, const cha
 				return NULL;
 			}
 
-			if (!is_set(CFGF_MULTI, secopt->flags) && (seccfg = cfg_opt_getnsec(secopt, 0)) != 0)
+			if (!is_set(CFGF_MULTI, secopt->flags) && (seccfg = cfg_opt_getnsec(secopt, 0)) != NULL)
 				opts = seccfg->opts;
 			else
 				opts = secopt->subopts;

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -350,22 +350,22 @@ extern const char __export confuse_author[];
 /** Initialize a string option
  */
 #define CFG_STR(name, def, flags) \
-  __CFG_STR(name, def, flags, 0, 0)
+  __CFG_STR(name, def, flags, NULL, NULL)
 
 /** Initialize a string list option
  */
 #define CFG_STR_LIST(name, def, flags) \
-  __CFG_STR_LIST(name, def, flags, 0, 0)
+  __CFG_STR_LIST(name, def, flags, NULL, NULL)
 
 /** Initialize a string option with a value parsing callback
  */
 #define CFG_STR_CB(name, def, flags, cb) \
-  __CFG_STR(name, def, flags, 0, cb)
+  __CFG_STR(name, def, flags, NULL, cb)
 
 /** Initialize a string list option with a value parsing callback
  */
 #define CFG_STR_LIST_CB(name, def, flags, cb) \
-  __CFG_STR_LIST(name, def, flags, 0, cb)
+  __CFG_STR_LIST(name, def, flags, NULL, cb)
 
 /** Initialize a "simple" string option.
  *
@@ -408,7 +408,7 @@ extern const char __export confuse_author[];
  * Alternatively, the default value can be set after the opts struct
  * is defined, as in:
  * <pre>
- * char *user = 0;
+ * char *user = NULL;
  * ...
  * cfg_opt_t opts[] = {
  *      CFG_SIMPLE_STR("user", &user),
@@ -420,7 +420,7 @@ extern const char __export confuse_author[];
  *
  */
 #define CFG_SIMPLE_STR(name, svalue) \
-  __CFG_STR(name, 0, CFGF_NONE, svalue, 0)
+  __CFG_STR(name, NULL, CFGF_NONE, svalue, NULL)
 
 
 #define __CFG_INT(_name, _def, _flags, _svalue, _cb) { \
@@ -443,22 +443,22 @@ extern const char __export confuse_author[];
 /** Initialize an integer option
  */
 #define CFG_INT(name, def, flags) \
-  __CFG_INT(name, def, flags, 0, 0)
+  __CFG_INT(name, def, flags, NULL, NULL)
 
 /** Initialize an integer list option
  */
 #define CFG_INT_LIST(name, def, flags) \
-  __CFG_INT_LIST(name, def, flags, 0, 0)
+  __CFG_INT_LIST(name, def, flags, NULL, NULL)
 
 /** Initialize an integer option with a value parsing callback
  */
 #define CFG_INT_CB(name, def, flags, cb) \
-  __CFG_INT(name, def, flags, 0, cb)
+  __CFG_INT(name, def, flags, NULL, cb)
 
 /** Initialize an integer list option with a value parsing callback
  */
 #define CFG_INT_LIST_CB(name, def, flags, cb) \
-  __CFG_INT_LIST(name, def, flags, 0, cb)
+  __CFG_INT_LIST(name, def, flags, NULL, cb)
 
 /** Initialize a "simple" integer option (see documentation for
  * CFG_SIMPLE_STR for more information).
@@ -467,7 +467,7 @@ extern const char __export confuse_author[];
  * Otherwise, you will have strange problems on 64-bit architectures.
  */
 #define CFG_SIMPLE_INT(name, svalue) \
-  __CFG_INT(name, 0, CFGF_NONE, svalue, 0)
+  __CFG_INT(name, 0, CFGF_NONE, svalue, NULL)
 
 
 
@@ -491,28 +491,28 @@ extern const char __export confuse_author[];
 /** Initialize a floating point option
  */
 #define CFG_FLOAT(name, def, flags) \
-  __CFG_FLOAT(name, def, flags, 0, 0)
+  __CFG_FLOAT(name, def, flags, NULL, NULL)
 
 /** Initialize a floating point list option
  */
 #define CFG_FLOAT_LIST(name, def, flags) \
-  __CFG_FLOAT_LIST(name, def, flags, 0, 0)
+  __CFG_FLOAT_LIST(name, def, flags, NULL, NULL)
 
 /** Initialize a floating point option with a value parsing callback
  */
 #define CFG_FLOAT_CB(name, def, flags, cb) \
-  __CFG_FLOAT(name, def, flags, 0, cb)
+  __CFG_FLOAT(name, def, flags, NULL, cb)
 
 /** Initialize a floating point list option with a value parsing callback
  */
 #define CFG_FLOAT_LIST_CB(name, def, flags, cb) \
-  __CFG_FLOAT_LIST(name, def, flags, 0, cb)
+  __CFG_FLOAT_LIST(name, def, flags, NULL, cb)
 
 /** Initialize a "simple" floating point option (see documentation for
  * CFG_SIMPLE_STR for more information).
  */
 #define CFG_SIMPLE_FLOAT(name, svalue) \
-  __CFG_FLOAT(name, 0, CFGF_NONE, svalue, 0)
+  __CFG_FLOAT(name, 0, CFGF_NONE, svalue, NULL)
 
 
 
@@ -536,28 +536,28 @@ extern const char __export confuse_author[];
 /** Initialize a boolean option
  */
 #define CFG_BOOL(name, def, flags) \
-  __CFG_BOOL(name, def, flags, 0, 0)
+  __CFG_BOOL(name, def, flags, NULL, NULL)
 
 /** Initialize a boolean list option
  */
 #define CFG_BOOL_LIST(name, def, flags) \
-  __CFG_BOOL_LIST(name, def, flags, 0, 0)
+  __CFG_BOOL_LIST(name, def, flags, NULL, NULL)
 
 /** Initialize a boolean option with a value parsing callback
  */
 #define CFG_BOOL_CB(name, def, flags, cb) \
-  __CFG_BOOL(name, def, flags, 0, cb)
+  __CFG_BOOL(name, def, flags, NULL, cb)
 
 /** Initialize a boolean list option with a value parsing callback
  */
 #define CFG_BOOL_LIST_CB(name, def, flags, cb) \
-  __CFG_BOOL_LIST(name, def, flags, 0, cb)
+  __CFG_BOOL_LIST(name, def, flags, NULL, cb)
 
 /** Initialize a "simple" boolean option (see documentation for
  * CFG_SIMPLE_STR for more information).
  */
 #define CFG_SIMPLE_BOOL(name, svalue) \
-  __CFG_BOOL(name, cfg_false, CFGF_NONE, svalue, 0)
+  __CFG_BOOL(name, cfg_false, CFGF_NONE, svalue, NULL)
 
 
 
@@ -626,12 +626,12 @@ extern const char __export confuse_author[];
  * @see cfg_callback_t, cfg_free_func_t
  */
 #define CFG_PTR_CB(name, def, flags, parsecb, freecb) \
-  __CFG_PTR(name, def, flags, 0, parsecb, freecb)
+  __CFG_PTR(name, def, flags, NULL, parsecb, freecb)
 
 /** Initialize a list of user-defined options
  */
 #define CFG_PTR_LIST_CB(name, def, flags, parsecb, freecb) \
-  __CFG_PTR(name, def, flags | CFGF_LIST, 0, parsecb, freecb)
+  __CFG_PTR(name, def, flags | CFGF_LIST, NULL, parsecb, freecb)
 
 /*#define CFG_SIMPLE_PTR(name, svalue, cb) \
   __CFG_PTR(name, 0, 0, svalue, cb)*/

--- a/src/confuse.h
+++ b/src/confuse.h
@@ -330,10 +330,22 @@ extern const char __export confuse_copyright[];
 extern const char __export confuse_version[];
 extern const char __export confuse_author[];
 
-#define __CFG_STR(name, def, flags, svalue, cb) \
-  {name,0,CFGT_STR,0,0,flags,0,{0,0,cfg_false,def,0},0,{.string=svalue},cb,0,0,0,0}
-#define __CFG_STR_LIST(name, def, flags, svalue, cb) \
-  {name,0,CFGT_STR,0,0,flags | CFGF_LIST,0,{0,0,cfg_false,0,def},0,{.string=svalue},cb,0,0,0,0}
+#define __CFG_STR(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_STR, \
+	.flags = _flags, \
+	.def = { .string = _def, }, \
+	.simple_value = { .string = _svalue, }, \
+	.parsecb = _cb, \
+}
+#define __CFG_STR_LIST(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_STR, \
+	.flags = _flags | CFGF_LIST, \
+	.def = { .parsed = _def, }, \
+	.simple_value = { .string = _svalue, }, \
+	.parsecb = _cb, \
+}
 
 /** Initialize a string option
  */
@@ -411,10 +423,22 @@ extern const char __export confuse_author[];
   __CFG_STR(name, 0, CFGF_NONE, svalue, 0)
 
 
-#define __CFG_INT(name, def, flags, svalue, cb) \
-  {name,0,CFGT_INT,0,0,flags,0,{def,0,cfg_false,0,0},0,{.number=svalue},cb,0,0,0,0}
-#define __CFG_INT_LIST(name, def, flags, svalue, cb) \
-  {name,0,CFGT_INT,0,0,flags | CFGF_LIST,0,{0,0,cfg_false,0,def},0,{.number=svalue},cb,0,0,0,0}
+#define __CFG_INT(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_INT, \
+	.flags = _flags, \
+	.def = { .number = _def, }, \
+	.simple_value = { .number = _svalue, }, \
+	.parsecb = _cb, \
+}
+#define __CFG_INT_LIST(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_INT, \
+	.flags = _flags | CFGF_LIST, \
+	.def = { .parsed = _def, }, \
+	.simple_value = { .number = _svalue, }, \
+	.parsecb = _cb, \
+}
 
 /** Initialize an integer option
  */
@@ -447,10 +471,22 @@ extern const char __export confuse_author[];
 
 
 
-#define __CFG_FLOAT(name, def, flags, svalue, cb) \
-  {name,0,CFGT_FLOAT,0,0,flags,0,{0,def,cfg_false,0,0},0,{.fpnumber=svalue},cb,0,0,0,0}
-#define __CFG_FLOAT_LIST(name, def, flags, svalue, cb) \
-  {name,0,CFGT_FLOAT,0,0,flags | CFGF_LIST,0,{0,0,cfg_false,0,def},0,{.fpnumber=svalue},cb,0,0,0,0}
+#define __CFG_FLOAT(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_FLOAT, \
+	.flags = _flags, \
+	.def = { .fpnumber = _def, }, \
+	.simple_value = { .fpnumber = _svalue, }, \
+	.parsecb = _cb, \
+}
+#define __CFG_FLOAT_LIST(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_FLOAT, \
+	.flags = _flags | CFGF_LIST, \
+	.def = { .parsed = _def, }, \
+	.simple_value = { .fpnumber = _svalue, }, \
+	.parsecb = _cb, \
+}
 
 /** Initialize a floating point option
  */
@@ -480,10 +516,22 @@ extern const char __export confuse_author[];
 
 
 
-#define __CFG_BOOL(name, def, flags, svalue, cb) \
-  {name,0,CFGT_BOOL,0,0,flags,0,{0,0,def,0,0},0,{.boolean=svalue},cb,0,0,0,0}
-#define __CFG_BOOL_LIST(name, def, flags, svalue, cb) \
-  {name,0,CFGT_BOOL,0,0,flags | CFGF_LIST,0,{0,0,cfg_false,0,def},0,{.boolean=svalue},cb,0,0,0,0}
+#define __CFG_BOOL(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_BOOL, \
+	.flags = _flags, \
+	.def = { .boolean = _def, }, \
+	.simple_value = { .boolean = _svalue, }, \
+	.parsecb = _cb, \
+}
+#define __CFG_BOOL_LIST(_name, _def, _flags, _svalue, _cb) { \
+	.name = _name, \
+	.type = CFGT_BOOL, \
+	.flags = _flags | CFGF_LIST, \
+	.def = { .parsed = _def, }, \
+	.simple_value = { .boolean = _svalue, }, \
+	.parsecb = _cb, \
+}
 
 /** Initialize a boolean option
  */
@@ -524,8 +572,12 @@ extern const char __export confuse_author[];
  * cfg_gettsec() function)
  *
  */
-#define CFG_SEC(name, opts, flags) \
-  {name,0,CFGT_SEC,0,0,flags,opts,{0,0,cfg_false,0,0},0,{0},0,0,0,0,0}
+#define CFG_SEC(_name, _opts, _flags) { \
+	.name = _name, \
+	.type = CFGT_SEC, \
+	.flags = _flags, \
+	.subopts = _opts, \
+}
 
 
 
@@ -535,14 +587,31 @@ extern const char __export confuse_author[];
  *
  * @see cfg_func_t
  */
-#define CFG_FUNC(name, func) \
-  {name,0,CFGT_FUNC,0,0,CFGF_NONE,0,{0,0,cfg_false,0,0},func,{0},0,0,0,0,0}
+#define CFG_FUNC(_name, _func) { \
+	.name = _name, \
+	.type = CFGT_FUNC, \
+	.func = _func, \
+}
 
 
-#define __CFG_PTR(name, def, flags, svalue, parsecb, freecb) \
-  {name,0,CFGT_PTR,0,0,flags,0,{0,0,cfg_false,0,def},0,{.ptr=svalue},parsecb,0,0,0,freecb}
-#define __CFG_PTR_LIST(name, def, flags, svalue, parsecb, freecb) \
-  {name,0,CFGT_PTR,0,0,flags | CFGF_LIST,0,{0,0,cfg_false,0,def},0,{.ptr=svalue},parsecb,0,0,0,freecb}
+#define __CFG_PTR(_name, _def, _flags, _svalue, _parsecb, _freecb) { \
+	.name = _name, \
+	.type = CFGT_PTR, \
+	.flags = _flags, \
+	.def = { .parsed = _def, }, \
+	.simple_value = { .ptr = _svalue, }, \
+	.parsecb = _parsecb, \
+	.freecb = _freecb, \
+}
+#define __CFG_PTR_LIST(name, def, flags, svalue, parsecb, freecb) { \
+	.name = _name, \
+	.type = CFGT_PTR, \
+	.flags = _flags | CFGF_LIST, \
+	.def = { .parsed = _def, }, \
+	.simple_value = { .ptr = _svalue, }, \
+	.parsecb = _parsecb, \
+	.freecb = _freecb, \
+}
 
 /** Initialize a user-defined option
  *
@@ -572,7 +641,7 @@ extern const char __export confuse_author[];
  * the option list.
  */
 #define CFG_END() \
-  {0,0,CFGT_NONE,0,0,CFGF_NONE,0,{0,0,cfg_false,0,0},0,{0},0,0,0,0,0}
+  { .type = CFGT_NONE, }
 
 
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -141,7 +141,7 @@ void cfg_scan_fp_end(void);
     if(e && e[1] == '-')
         *e = 0;
     else
-        e = 0;
+        e = NULL;
     var = getenv(yytext+2);
     if(!var && e)
         var = e+2;
@@ -271,7 +271,7 @@ $\{[^}]*\} {
     if (e && e[1] == '-')
         *e = 0;
     else
-        e = 0;
+        e = NULL;
     var = getenv(yytext+2);
     if (!var && e)
         var = e+2;
@@ -300,7 +300,7 @@ void cfg_dummy_function(void)
     /* please compiler :-)
      * otherwise "defined but not used" warning
      */
-    yyunput(0, 0);
+    yyunput(0, NULL);
 }
 
 int cfg_lexer_include(cfg_t *cfg, const char *filename)


### PR DESCRIPTION
When working on [genimage](https://github.com/pengutronix/genimage) and trying to make it sparse clean I noticed that most warnings there originate from libconfuse. This pull request addresses the warnings

        warning: Using plain integer as NULL pointer

. The first two fix these in the public header, the third commit fixes the source code of libconfuse itself.
