### PR TITLE
Added arch ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # Travis CI integration
 # Defaults to GNU GCC and autotools: ./configure && make && make test
+arch:
+ - amd64
+ - ppc64le
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Travis CI integration
 # Defaults to GNU GCC and autotools: ./configure && make && make test
+
 language: c
 
 # Use docker for quicker builds, it now allows https://docs.travis-ci.com/user/apt/


### PR DESCRIPTION
Hi
Added power support for the travis.yml file with ppc64le. 
This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.