### PR TITLE
Annotate cfg_error with format attribute

### DIFF
--- a/src/confuse.h
+++ b/src/confuse.h
@@ -770,6 +770,9 @@ DLLIMPORT cfg_errfunc_t __export cfg_set_error_function(cfg_t *cfg, cfg_errfunc_
 /** Show a parser error. Any user-defined error reporting function is called.
  * @see cfg_set_error_function
  */
+#ifdef __GNUC__
+__attribute__((__format__(__printf__, 2, 3)))
+#endif
 DLLIMPORT void __export cfg_error(cfg_t *cfg, const char *fmt, ...);
 
 /** Returns the option comment


### PR DESCRIPTION
Format attributes help compilers to warn on format string misuses, like:

    cfg_error(cfg, user_defined_input)  // potential security issue
    cfg_error(cfg, "foo %d", "bar")


    confuse.c:1246:20: warning: format string is not a string literal [-Wformat-nonliteral]
                    vfprintf(stderr, fmt, ap);
                                     ^~~

Guard the annotation with `__GNUC__`, defined by GCC and Clang, which support the GNU extension of function format attributes.

TODO: Untested on Windows.