### PR TITLE
cmake VERSION format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # The bundled autogen.sh script does this and also calls autoamake. 
 AC_PREREQ(2.50)
 
-AC_INIT(libConfuse, 3.4-dev, https://github.com/libconfuse/libconfuse/issues, confuse)
+AC_INIT(libConfuse, 3.4, https://github.com/libconfuse/libconfuse/issues, confuse)
 AC_CONFIG_AUX_DIR(support)
 AM_INIT_AUTOMAKE([foreign dist-xz])
 AM_SILENT_RULES([no])


### PR DESCRIPTION
I suggest use cmake version format <major>[.<minor>[.<patch>[.<tweak>]]] see details https://cmake.org/cmake/help/latest/command/project.html

Because in future libconfuse should use cmake (and conan) build system https://github.com/myd7349/libconfuse.cmake

"3.4-dev" brokes cmake with:
CMake Error at CMakeLists.txt:20 (project):
  VERSION "3.4-dev" format invalid.